### PR TITLE
Pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Translation Proxy Terraform Module
+
+This README aims to provide a concise guide on how the provided Terraform module sets up a translation proxy using AWS CloudFront and other related services.
+
+## Overview
+
+The Terraform module essentially establishes an AWS CloudFront distribution tailored to serve localized content. It dynamically reroutes certain requests to `service.prerender.io` for better SEO optimization and intelligently manages caching policies to balance responsiveness with resource utilization.
+
+### Components:
+
+1. **CloudFront Distribution**: Serves the translated content with the help of Lambda@Edge for request and response manipulations.
+2. **Lambda@Edge**: Two Lambda functions intercept the viewer and origin requests. These functions:
+    - Identify bots to prerender content for SEO optimization.
+    - Redirect requests to `service.prerender.io` when needed.
+3. **CloudFront Cache Policy**: Determines caching behavior based on headers, cookies, and query strings. Cache policies ensure that the dynamic nature of translated content is handled efficiently without compromising speed.
+
+## Variables Explained
+
+- **`locale`**: Specifies the target language or region using a two-by-two locale code, e.g., "en-US" or "fr-FR".
+
+- **`domain`**: The fully qualified domain name (FQDN) intended for serving the translations. This determines the URL where end users access the localized content.
+
+- **`project`**: The project ID given by the Language Service Provider (LSP). This is essential to link the infrastructure to a specific translation project.
+
+- **`app_domain`**: The domain provided by the LSP which typically hosts the translated content or applications.
+
+- **`min_tls_version`**: The minimum TLS version CloudFront should accept for secure connections. The default is "TLSv1.1_2016", but can be modified based on security requirements.
+
+- **`caching_min_ttl`**, **`caching_default_ttl`**, **`caching_max_ttl`**: These variables manage the Time-To-Live (TTL) settings for CloudFront's caching. They determine how long content stays in the cache before a new version is retrieved.
+
+## Behind the Scenes: How it Works
+
+1. When a user accesses the content using the FQDN specified in `domain`, the request hits the CloudFront distribution.
+
+2. Lambda@Edge functions inspect this request:
+    - If the user agent matches certain bot criteria (like Googlebot or Bingbot), the request gets flagged for prerendering.
+    - Headers are adjusted for such requests, which include tokens and host information for `service.prerender.io`.
+
+3. For prerender-flagged requests, instead of serving directly from CloudFront, the Lambda function redirects the request to `service.prerender.io`.
+
+4. Responses, either from `service.prerender.io` or directly from the origin specified by `app_domain`, are then served to the user through CloudFront.
+
+5. The CloudFront cache policy ensures that caching behavior considers query strings, headers, and cookies. This is crucial as translated content can be dynamic and may change based on various factors.
+
+## Deployment and Integration
+
+To utilize this Terraform module, integrate it with your main Terraform script and adjust the necessary variables as per your project requirements. Make sure to handle AWS credentials and region settings appropriately in your Terraform environment to ensure seamless deployment.

--- a/cache-policy.tf
+++ b/cache-policy.tf
@@ -1,0 +1,34 @@
+resource "aws_cloudfront_cache_policy" "caching_with_queries" {
+  name = "translationproxy-${var.project}_${var.locale}"
+
+  comment = "Generic cache settings permitting query params"
+
+  min_ttl     = var.caching_min_ttl
+  default_ttl = var.caching_default_ttl
+  max_ttl     = var.caching_max_ttl
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "all"
+    }
+
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = [
+          "Origin",
+          "Accept",
+          "CloudFront-Forwarded-Proto",
+          "Referer",
+          "User-Agent",
+          "X-TranslationProxy-CrawlingFor",
+          "Accept-Language",
+        ]
+      }
+    }
+
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+  }
+}

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -4,6 +4,8 @@ resource "aws_cloudfront_distribution" "translations_at_root" {
     var.domain
   ]
 
+  comment = "translationproxy_${var.project}_${var.locale}"
+
   tags = {
     product = "translationproxy",
     project = var.project,
@@ -27,20 +29,20 @@ resource "aws_cloudfront_distribution" "translations_at_root" {
 
     lambda_function_association {
       event_type   = "viewer-request"
-      lambda_arn   = data.aws_lambda_function.set_prerender_header.qualified_arn
+      lambda_arn = aws_lambda_function.prerender_headers.qualified_arn
       include_body = true
     }
 
     lambda_function_association {
       event_type   = "origin-request"
-      lambda_arn   = data.aws_lambda_function.redirect_to_prerender.qualified_arn
+      lambda_arn   = aws_lambda_function.prerender_redirect.qualified_arn
       include_body = true
     }
 
     target_origin_id       = "translationproxy-${var.locale}"
     viewer_protocol_policy = "allow-all"
 
-    cache_policy_id = var.cache_policy_id
+    cache_policy_id = aws_cloudfront_cache_policy.caching_with_queries.id
   }
 
   origin {

--- a/lambda.tf
+++ b/lambda.tf
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "prerender_headers" {
 
   source_code_hash = data.archive_file.prerender_headers.output_base64sha256
 
-  runtime = "nodejs14.x"
+  runtime = "nodejs18.x"
   handler = "prerender-headers.handler"
   publish = true
 
@@ -52,7 +52,7 @@ resource "aws_lambda_function" "prerender_redirect" {
 
   source_code_hash = data.archive_file.redirect_to_prerender.output_base64sha256
 
-  runtime = "nodejs14.x"
+  runtime = "nodejs18.x"
   handler = "redirect.handler"
   publish = true
 

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,7 +1,63 @@
-data "aws_lambda_function" "set_prerender_header" {
-  function_name = "crest-prerender-test-SetPrerenderHeader-TtxzCLiZqbo6"
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com", "edgelambda.amazonaws.com",]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
 }
 
-data "aws_lambda_function" "redirect_to_prerender" {
-  function_name = "crest-prerender-test-RedirectToPrerender-FBhJ3KhHMR9K"
+resource "aws_iam_role" "iam_for_lambda" {
+  name               = "lambda-execution_${var.project}_${var.locale}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "archive_file" "prerender_headers" {
+  type        = "zip"
+  source_file = "${path.module}/prerender-headers.js"
+  output_path = "${path.module}/prerender-headers.zip"
+}
+
+data "archive_file" "redirect_to_prerender" {
+  type        = "zip"
+  source_file = "${path.module}/redirect.js"
+  output_path = "${path.module}/redirect.zip"
+}
+
+resource "aws_lambda_function" "prerender_headers" {
+  filename      = "${path.module}/prerender-headers.zip"
+  function_name = "set-prerender-headers_${var.project}"
+  role          = aws_iam_role.iam_for_lambda.arn
+
+  source_code_hash = data.archive_file.prerender_headers.output_base64sha256
+
+  runtime = "nodejs14.x"
+  handler = "prerender-headers.handler"
+  publish = true
+
+  tags = {
+    product = "translationproxy",
+    project = var.project,
+  }
+}
+
+resource "aws_lambda_function" "prerender_redirect" {
+  filename      = "${path.module}/redirect.zip"
+  function_name = "redirect-to-prerender_${var.project}"
+  role          = aws_iam_role.iam_for_lambda.arn
+
+  source_code_hash = data.archive_file.redirect_to_prerender.output_base64sha256
+
+  runtime = "nodejs14.x"
+  handler = "redirect.handler"
+  publish = true
+
+  tags = {
+    product = "translationproxy",
+    project = var.project,
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.14.0"
+    }
+  }
+}
+
+provider "aws" {
+  default_tags {
+    tags = {
+      terraformed = true
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,20 +13,9 @@ variable "project" {
   type        = string
 }
 
-variable "forward_query_strings" {
-  description = "Forward query strings to Easyling. CAUTION: may decrease effectiveness of caching, and lead to greater traffic numbers."
-  default     = false
-  type        = bool
-}
-
 variable "app_domain" {
   description = "App domain provided by LSP"
   type        = string
-}
-
-variable "acm_cert_arn" {
-  description = "ARN of the dynamic certificate provisioned by AWS. Can be left empty, in which case HTTPS will not work!"
-  default     = ""
 }
 
 variable "min_tls_version" {
@@ -35,8 +24,20 @@ variable "min_tls_version" {
   default     = "TLSv1.1_2016"
 }
 
-variable "cache_policy_id" {
-  type = string
-  description = "Cache policy ID for CF"
-  default = "34ddda49-18dd-416c-94c9-728cbbbc6a42"
+variable "caching_min_ttl" {
+  type = number
+  description = "Minimum TTL for CloudFront cache in seconds"
+  default = 1
+}
+
+variable "caching_default_ttl" {
+  type = number
+  description = "Default TTL for CloudFront cache in seconds, in the absence of other directives"
+  default = 300
+}
+
+variable "caching_max_ttl" {
+  type = number
+  description = "Maximum TTL for CloudFront cache in seconds"
+  default = 86400
 }


### PR DESCRIPTION
Improve the module by preferring _convention_ over _customization_, given that Terraform, at its core, is an *opinionated* system/language. By limiting customization and ensuring that all resources are created, the module becomes more _atomic_, more _self-contained_, and becomes easier to document.